### PR TITLE
Fix #3 (mostly)

### DIFF
--- a/resources/header.html
+++ b/resources/header.html
@@ -1,4 +1,4 @@
-<meta name='viewport' content='width=device-width, initial-scale=1' />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 
 <style>
   body {
@@ -11,33 +11,57 @@
   }
 </style>
 
-<script type='text/javascript'
-        id='MathJax-script'
-        src='{{ mathjax-js }}'></script>
+<script
+  type="text/javascript"
+  id="MathJax-script"
+  src="{{ mathjax-js }}"
+></script>
 
-<script type='text/javascript'
-        src='{{ highlight-js }}'></script>
+<script type="text/javascript" src="{{ highlight-js }}"></script>
 
-<script type='text/javascript'
-        src='{{ mermaid-js }}'></script>
+<script type="text/javascript" src="{{ mermaid-js }}"></script>
 
-<script>
- // Use highlight.js for syntax highlighting on non-mermaid code blocks.
- hljs.configure({noHighlightRe: /^mermaid$/i});
- hljs.highlightAll();
+<script type="text/javascript">
+  // Use highlight.js for syntax highlighting on non-mermaid code blocks.
+  hljs.configure({ noHighlightRe: /^mermaid$/i });
+  hljs.highlightAll();
 </script>
 
-<script>
-  // Add a "markdown-body" class attribute to the body. We must do this because
-  // the GitHub CSS only applies to a div with the "markdown-body" class.
-  document.addEventListener('DOMContentLoaded', (event) => {
-    document.body.classList.add('markdown-body');
+<script type="text/javascript">
+  mermaid.initialize({
+    theme: "{{ mermaid-theme }}",
+    startOnLoad: true,
   });
 </script>
 
-<script>
-mermaid.initialize({
-  theme: '{{ mermaid-theme }}',
-  startOnLoad: true
-});
+<script type="text/javascript">
+  document.addEventListener("DOMContentLoaded", (event) => {
+    // Add a "markdown-body" class attribute to the body. We must do this because
+    // the GitHub CSS only applies to a div with the "markdown-body" class.
+    document.body.classList.add("markdown-body");
+
+    // If there's a stored scroll location, restore it.
+    let prevScroll = localStorage.getItem("scrollY");
+    if (!isNaN(prevScroll)) {
+      window.scroll(0, prevScroll);
+      // Sometimes the scroll 'jumps' and doesn't go back to exactly where it
+      // should, this seems to (sometimes) fix that by just scrolling the
+      // missing distance
+      const current = window.scrollY;
+      if (prevScroll != current) window.scrollBy(0, prevScroll - current);
+    }
+  });
+
+  // Save new scroll locations on scroll.
+  // See: https://developer.mozilla.org/en-US/docs/Web/API/Document/scroll_event
+  let ticking = false;
+  document.addEventListener("scroll", (event) => {
+    if (!ticking) {
+      window.requestAnimationFrame(() => {
+        localStorage.setItem("scrollY", window.scrollY);
+        ticking = false;
+      });
+      ticking = true;
+    }
+  });
 </script>

--- a/resources/header.html
+++ b/resources/header.html
@@ -35,33 +35,18 @@
 </script>
 
 <script type="text/javascript">
-  document.addEventListener("DOMContentLoaded", (event) => {
+  document.addEventListener("DOMContentLoaded", () => {
     // Add a "markdown-body" class attribute to the body. We must do this because
     // the GitHub CSS only applies to a div with the "markdown-body" class.
     document.body.classList.add("markdown-body");
 
     // If there's a stored scroll location, restore it.
-    let prevScroll = localStorage.getItem("scrollY");
-    if (!isNaN(prevScroll)) {
-      window.scroll(0, prevScroll);
-      // Sometimes the scroll 'jumps' and doesn't go back to exactly where it
-      // should, this seems to (sometimes) fix that by just scrolling the
-      // missing distance
-      const current = window.scrollY;
-      if (prevScroll != current) window.scrollBy(0, prevScroll - current);
-    }
+    let prevScroll = sessionStorage.getItem("scrollY");
+    if (prevScroll) window.scroll(0, prevScroll);
   });
 
-  // Save new scroll locations on scroll.
-  // See: https://developer.mozilla.org/en-US/docs/Web/API/Document/scroll_event
-  let ticking = false;
-  document.addEventListener("scroll", (event) => {
-    if (!ticking) {
-      window.requestAnimationFrame(() => {
-        localStorage.setItem("scrollY", window.scrollY);
-        ticking = false;
-      });
-      ticking = true;
-    }
+  // Save last scroll location before the page unloads.
+  window.addEventListener("beforeunload", () => {
+    sessionStorage.setItem("scrollY", window.scrollY);
   });
 </script>

--- a/resources/header.html
+++ b/resources/header.html
@@ -40,13 +40,22 @@
     // the GitHub CSS only applies to a div with the "markdown-body" class.
     document.body.classList.add("markdown-body");
 
-    // If there's a stored scroll location, restore it.
+    // If there's a stored scroll location, scroll to that location. Otherwise,
+    // the document resets to the top of the page every time it is refreshed.
     let prevScroll = sessionStorage.getItem("scrollY");
     if (prevScroll) window.scroll(0, prevScroll);
   });
 
-  // Save last scroll location before the page unloads.
-  window.addEventListener("beforeunload", () => {
-    sessionStorage.setItem("scrollY", window.scrollY);
+  // Save new scroll locations on scroll.
+  // See: https://developer.mozilla.org/en-US/docs/Web/API/Document/scroll_event
+  let ticking = false;
+  document.addEventListener("scroll", (event) => {
+    if (!ticking) {
+      window.requestAnimationFrame(() => {
+        sessionStorage.setItem("scrollY", window.scrollY);
+        ticking = false;
+      });
+      ticking = true;
+    }
   });
 </script>


### PR DESCRIPTION
This fixes the issue with the Xwidget buffer scrolling to the top of page on refresh. It stores the last scroll location in browser local storage, and then loads it on page refresh (well, technically on DOM content load so that we scroll after there's something *to* scroll).

It does have an issue where it sometimes will jump up the page slightly (a few text lines) from where you were, I'm really not sure what causes that. But that's a relatively minor problem I'd say.

Thanks for the great package / idea!