### PR TITLE
Add .elpaignore to prevent package-vc-install error

### DIFF
--- a/.elpaignore
+++ b/.elpaignore
@@ -1,0 +1,2 @@
+doc/installation/quelpa/init.el
+doc/installation/straight/init.el


### PR DESCRIPTION
When install with package-vc like
```elisp
(use-package markdown-xwidget
  :vc (markdown-xwidget
       :url "https://github.com/cfclrk/markdown-xwidget"
       :rev :newest)
  :demand t
  :after markdown-mode
  :custom
  (markdown-xwidget-github-theme (symbol-name (frame-parameter nil 'background-mode)))
  :bind
  (:map markdown-mode-command-map
        ("x" . markdown-xwidget-preview-mode)))
```
we will encounter
```
Debugger entered--Lisp error: (error "Package ‘use-package-ensure’ is unavailable")
  error("Package `use-package-ensure' is unavailable")
  package-compute-transaction(nil ((use-package-ensure)))
  package-install(use-package-ensure)
  use-package-ensure-elpa(use-package-ensure (t) nil)
  #<subr use-package-handler/:ensure>(use-package-ensure :ensure (t) (:preface ((eval-when-compile (with-demoted-errors "Cannot load use-package-ensure: %S" nil (unless (featurep 'use-package-ensure) (load "use-package-ensure" nil t))))) :catch t :init nil :defer t :config ((setq use-package-ensure-function 'quelpa) (setq use-package-always-ensure t))) nil)
  vc-use-package--override-:ensure(#<subr use-package-handler/:ensure> use-package-ensure :ensure (t) (:preface ((eval-when-compile (with-demoted-errors "Cannot load use-package-ensure: %S" nil (unless (featurep 'use-package-ensure) (load "use-package-ensure" nil t))))) :catch t :init nil :defer t :config ((setq use-package-ensure-function 'quelpa) (setq use-package-always-ensure t))) nil)
  apply(vc-use-package--override-:ensure #<subr use-package-handler/:ensure> (use-package-ensure :ensure (t) (:preface ((eval-when-compile (with-demoted-errors "Cannot load use-package-ensure: %S" nil (unless (featurep ...) (load "use-package-ensure" nil t))))) :catch t :init nil :defer t :config ((setq use-package-ensure-function 'quelpa) (setq use-package-always-ensure t))) nil))
  use-package-handler/:ensure(use-package-ensure :ensure (t) (:preface ((eval-when-compile (with-demoted-errors "Cannot load use-package-ensure: %S" nil (unless (featurep 'use-package-ensure) (load "use-package-ensure" nil t))))) :catch t :init nil :defer t :config ((setq use-package-ensure-function 'quelpa) (setq use-package-always-ensure t))) nil)
  use-package-process-keywords(use-package-ensure (:ensure (t) :preface ((eval-when-compile (with-demoted-errors "Cannot load use-package-ensure: %S" nil (unless (featurep 'use-package-ensure) (load "use-package-ensure" nil t))))) :catch t :init nil :defer t :config ((setq use-package-ensure-function 'quelpa) (setq use-package-always-ensure t))) nil)
  #f(compiled-function (name &rest args) "Declare an Emacs package by specifying a group of configuration options.\n\nFor the full documentation, see Info node `(use-package) top'.\nUsage:\n\n  (use-package package-name\n     [:keyword [option]]...)\n\n:init            Code to run before PACKAGE-NAME has been loaded.\n:config          Code to run after PACKAGE-NAME has been loaded.  Note that\n                 if loading is deferred for any reason, this code does not\n                 execute until the lazy load has occurred.\n:preface         Code to be run before everything except `:disabled'; this\n                 can be used to define functions for use in `:if', or that\n                 should be seen by the byte-compiler.\n\n:mode            Form to be added to `auto-mode-alist'.\n:magic           Form to be added to `magic-mode-alist'.\n:magic-fallback  Form to be added to `magic-fallback-mode-alist'.\n:interpreter     Form to be added to `interpreter-mode-alist'.\n\n:commands        Define autoloads for commands that will be defined by the\n                 package.  This is useful if the package is being lazily\n                 loaded, and you wish to conditionally call functions in your\n                 `:init' block that are defined in the package.\n:autoload        Similar to :commands, but it for no-interactive one.\n:hook            Specify hook(s) to attach this package to.\n\n:bind            Bind keys, and define autoloads for the bound commands.\n:bind*           Bind keys, and define autoloads for the bound commands,\n                 *overriding all minor mode bindings*.\n:bind-keymap     Bind a key prefix to an auto-loaded keymap defined in the\n                 package.  This is like `:bind', but for keymaps.\n:bind-keymap*    Like `:bind-keymap', but overrides all minor mode bindings\n\n:defer           Defer loading of a package -- this is implied when using\n                 `:commands', `:bind', `:bind*', `:mode', `:magic', `:hook',\n                 `:magic-fallback', or `:interpreter'.  This can be an integer,\n                 to force loading after N seconds of idle time, if the package\n                 has not already been loaded.\n:demand          Prevent the automatic deferred loading introduced by constructs\n                 such as `:bind' (see `:defer' for the complete list).\n\n:after           Delay the effect of the use-package declaration\n                 until after the named libraries have loaded.\n                 Before they have been loaded, no other keyword\n                 has any effect at all, and once they have been\n                 loaded it is as if `:after' was not specified.\n\n:if EXPR         Initialize and load only if EXPR evaluates to a non-nil value.\n:disabled        The package is ignored completely if this keyword is present.\n:defines         Declare certain variables to silence the byte-compiler.\n:functions       Declare certain functions to silence the byte-compiler.\n:load-path       Add to the `load-path' before attempting to load the package.\n:diminish        Support for diminish.el (if installed).\n:delight         Support for delight.el (if installed).\n:custom          Call `Custom-set' or `set-default' with each variable\n                 definition without modifying the Emacs `custom-file'.\n                 (compare with `custom-set-variables').\n:custom-face     Call `custom-set-faces' with each face definition.\n:ensure          Loads the package using package.el if necessary.\n:pin             Pin the package to an archive." #<bytecode -0x8ca81d77657609>)(use-package-ensure :config (setq use-package-ensure-function 'quelpa) (setq use-package-always-ensure t))
  macroexpand((use-package use-package-ensure :config (setq use-package-ensure-function 'quelpa) (setq use-package-always-ensure t)) ((declare-function . byte-compile-macroexpand-declare-function) (eval-when-compile . #f(compiled-function (&rest body) #<bytecode 0x29a0e513cc14363>)) (eval-and-compile . #f(compiled-function (&rest body) #<bytecode 0xf6e76fc1a83e6b5>)) (with-suppressed-warnings . #f(compiled-function (warnings &rest body) #<bytecode -0x1936b9ff4245bf53>))))
  macroexp-macroexpand((use-package use-package-ensure :config (setq use-package-ensure-function 'quelpa) (setq use-package-always-ensure t)) ((declare-function . byte-compile-macroexpand-declare-function) (eval-when-compile . #f(compiled-function (&rest body) #<bytecode 0x29a0e513cc14363>)) (eval-and-compile . #f(compiled-function (&rest body) #<bytecode 0xf6e76fc1a83e6b5>)) (with-suppressed-warnings . #f(compiled-function (warnings &rest body) #<bytecode -0x1936b9ff4245bf53>))))
  byte-compile-recurse-toplevel((use-package use-package-ensure :config (setq use-package-ensure-function 'quelpa) (setq use-package-always-ensure t)) #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_46>)
  byte-compile-toplevel-file-form((use-package use-package-ensure :config (setq use-package-ensure-function 'quelpa) (setq use-package-always-ensure t)))
  #<subr F616e6f6e796d6f75732d6c616d626461_anonymous_lambda_44>(#<buffer  *Compiler Input*>)
  byte-compile-from-buffer(#<buffer  *Compiler Input*>)
  byte-compile-file("/Users/xuchu1/.emacs.d/elpa/markdown-xwidget/doc/i...")
  byte-recompile-file("/Users/xuchu1/.emacs.d/elpa/markdown-xwidget/doc/i..." t 0)
  #f(compiled-function () #<bytecode 0xd83ed373c92a5c6>)()
  byte-recompile-directory("/Users/xuchu1/.emacs.d/elpa/markdown-xwidget/" 0 t)
  package--compile(#s(package-desc :name markdown-xwidget :version (0 1) :summary "No description available." :reqs nil :kind vc :archive nil :dir "/Users/xuchu1/.emacs.d/elpa/markdown-xwidget/" :extras nil :signed nil))
  package-vc--unpack-1(#s(package-desc :name markdown-xwidget :version nil :summary "No description available." :reqs nil :kind vc :archive nil :dir "/Users/xuchu1/.emacs.d/elpa/markdown-xwidget/" :extras nil :signed nil) "/Users/xuchu1/.emacs.d/elpa/markdown-xwidget/")
  package-vc--unpack(#s(package-desc :name markdown-xwidget :version nil :summary "No description available." :reqs nil :kind vc :archive nil :dir "/Users/xuchu1/.emacs.d/elpa/markdown-xwidget/" :extras nil :signed nil) (:url "https://github.com/cfclrk/markdown-xwidget" :rev :newest) nil)
  package-vc-install((markdown-xwidget :url "https://github.com/cfclrk/markdown-xwidget" :rev :newest))
  vc-use-package--install(:verbatim (markdown-xwidget :url "https://github.com/cfclrk/markdown-xwidget" :rev :newest))
  apply(vc-use-package--install (:verbatim (markdown-xwidget :url "https://github.com/cfclrk/markdown-xwidget" :rev :newest)))
  (progn (use-package-ensure-elpa 'markdown-xwidget 'nil '(:demand t)) (apply #'vc-use-package--install '(:verbatim (markdown-xwidget :url "https://github.com/cfclrk/markdown-xwidget" :rev :newest))) (defvar use-package--warning270 #'(lambda (keyword err) (let ((msg (format "%s/%s: %s" ... keyword ...))) (display-warning 'use-package msg :error)))) (condition-case err (eval-after-load 'markdown-mode #'(lambda nil (progn (let (...) (if ... nil ... ... ...) (custom-theme-set-variables ... ...)) (if (not ...) (display-warning ... ... :error)) (if (boundp ...) (let* ... ... ... ...) (eval-after-load ... ...))))) ((debug error) (funcall use-package--warning270 :catch err))))
  (progn (progn (use-package-ensure-elpa 'markdown-xwidget 'nil '(:demand t)) (apply #'vc-use-package--install '(:verbatim (markdown-xwidget :url "https://github.com/cfclrk/markdown-xwidget" :rev :newest))) (defvar use-package--warning270 #'(lambda (keyword err) (let ((msg ...)) (display-warning 'use-package msg :error)))) (condition-case err (eval-after-load 'markdown-mode #'(lambda nil (progn (let ... ... ...) (if ... ...) (if ... ... ...)))) ((debug error) (funcall use-package--warning270 :catch err)))))
  ```
This is because `package--compile` will compile all files in the dir by `byte-recompile-directory`, we can add `.elpaignore` to ignore files we do not want byte compile.